### PR TITLE
Fix #8: only start the WC session where it is actually used (stop forcing an empty session cookie on every page)

### DIFF
--- a/includes/class-wpfactory-wc-eu-vat-ajax.php
+++ b/includes/class-wpfactory-wc-eu-vat-ajax.php
@@ -192,6 +192,10 @@ class WPFactory_WC_EU_VAT_AJAX {
 			'vat_valid_but_not_exempted' => $vat_valid_but_not_exempted,
 		);
 
+		// The session cookie is no longer force-started on every page load;
+		// make sure it exists here so the validation result persists.
+		wpfactory_wc_eu_vat_session_start();
+
 		wpfactory_wc_eu_vat_session_set(
 			'wpfactory_wc_eu_vat',
 			wc_clean( $data['vat_number'] )

--- a/includes/class-wpfactory-wc-eu-vat-core.php
+++ b/includes/class-wpfactory-wc-eu-vat-core.php
@@ -734,7 +734,6 @@ class WPFactory_WC_EU_VAT_Core {
 	 * @since   1.0.0
 	 */
 	function start_session() {
-		wpfactory_wc_eu_vat_session_start();
 		$curl = rtrim( $this->current_url(), '/' );
 		$home = rtrim( home_url(), '/' );
 		if ( ! ( $curl == $home ) ) {


### PR DESCRIPTION
Fixes #8 — full analysis, reproduction steps and evidence are in that issue.

## What this changes

**1. `includes/class-wpfactory-wc-eu-vat-core.php` — `start_session()`**
Removes the unconditional `wpfactory_wc_eu_vat_session_start();` at the top of the function. The existing cart/checkout branch a few lines below still starts the session on the only front-end pages where this plugin reads or writes its session keys.

**2. `includes/class-wpfactory-wc-eu-vat-ajax.php` — `ajax_vat_validate()`**
Starts the session right before the handler stores the validation result, so nothing is lost on stores where this endpoint could be reached without an existing session.

## Why this is safe

- Every other `wpfactory_wc_eu_vat_session_set()` call site (checkout validation in `functions-validation.php`, the checkout block, core checkout hooks) runs in checkout/Store-API context, where WooCommerce guarantees a session exists (you cannot reach checkout without a cart, and a cart implies a session).
- The sessions the removed call used to create were empty — `set_customer_session_cookie( true )` without any data write, so no row was ever created in `woocommerce_sessions`. Removing it changes no persisted state.
- This aligns the plugin with WooCommerce's [10.3 developer advisory on empty sessions](https://developer.woocommerce.com/2025/10/06/experimental-clearing-empty-sessions-10-3/), which names exactly this pattern.

## Effect

Guest page views outside cart/checkout no longer carry a `Set-Cookie: wp_woocommerce_session_…` header, so page caches work again — and caches that store `Set-Cookie` responses can no longer hand one visitor's session token to another (shared-cart / checkout-data leak described in #8).

Both files pass `php -l`. Happy to adjust if you'd prefer the session start in a different spot.